### PR TITLE
fix: duplicate fields when using same variable twice in one entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,17 +52,26 @@ async function processFile(path: string) {
 		"export interface LocalesMap {",
 		...resource.body.filter(isMessage).map((entry) => {
 			if (!entry.value?.elements.filter(isPlaceable).length)
-				return `"${entry.id.name}": never;`;
+			    return `"${entry.id.name}": never;`;
+
+			const entryNames = new Set<string>(
+			    entry.value.elements.filter(isPlaceable).map((element) => {
+			        if (element.expression.type === "SelectExpression") {
+			            return element.expression.selector.id.name
+			        }
+
+			        return element.expression.id.name
+			    })
+			)
+
+			const entryLines = Array
+				.from(entryNames.values())
+				.map((name) => `"${name}": FluentVariable;`)
+				.join("\n")
+
 			return `"${entry.id.name}": {
-				${entry.value.elements
-					.filter(isPlaceable)
-					.map((element) => {
-						if (element.expression.type === "SelectExpression")
-							return `"${element.expression.selector.id.name}": FluentVariable;`;
-						return `"${element.expression.id.name}": FluentVariable;`;
-					})
-					.join("\n")}
-			}`;
+				${entryLines}
+			};`
 		}),
 		"}",
 		"",


### PR DESCRIPTION
Fixes this:

```fluent
entry =
    variable1 { $variable1 }
    variable2 { $variable2 }
    variable3 { $variable3 }
    repeatable variable { $variable }
    repeatable variable { $variable }
```

->

```ts
export interface LocalesMap {
    entry: {
        variable1: FluentVariable;
        variable2: FluentVariable;
        variable3: FluentVariable;
        variable: FluentVariable;
        variable: FluentVariable;
    }
}
```
